### PR TITLE
Fix red logic stop datatype to float

### DIFF
--- a/src/line_follower/line_follower/robot_ctrl.py
+++ b/src/line_follower/line_follower/robot_ctrl.py
@@ -286,8 +286,10 @@ class RobotCtrl(Node):
         if self.tl_red:
             self.get_logger().info("Traffic light RED, stopping robot.", throttle_duration_sec=2.0)
             # self.soft_stop()
-            v = 0
-            w = 0
+            v = 0.0
+            w = 0.0
+            self.cmd_vel.linear.x = v
+            self.cmd_vel.angular.z = -w
             self.cmd_vel_pub.publish(self.cmd_vel)
             return
         elif self.tl_yellow:


### PR DESCRIPTION
Update the stop command for the robot to use float values for linear and angular velocities. This change ensures consistency in data types when stopping the robot.